### PR TITLE
Fix test_mstore_mload_reflexivity function

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -114,7 +114,7 @@ def test_msize_incremented_on_mload():
 def test_mstore_mload_reflexivity():
     code = assemble(
     [
-        PUSH16, 0x00112233445566778899aabbccddeeff,
+        PUSH16, 0xff112233445566778899aabbccddeeff,
         PUSH1, 0,
         MSTORE,
         PUSH1, 0,
@@ -125,4 +125,4 @@ def test_mstore_mload_reflexivity():
     ])
 
     ret = run(code)
-    assert int.from_bytes(ret, 'big') == 0x00112233445566778899aabbccddeeff
+    assert int.from_bytes(ret, 'big') == 0xff112233445566778899aabbccddeeff


### PR DESCRIPTION
Code in test not assembling correctly, value being pushed onto the stack with PUSH16 was only 15 bytes long after removing the leading 00.

This changed the next opcode to actually be 00 (STOP), meaning this function's pytest failed.

Opted to switch the leading 00 to ff rather than change to PUSH15 for simplicity's sake.