### PR TITLE
Rework instruction registration

### DIFF
--- a/src/smol_evm/context.py
+++ b/src/smol_evm/context.py
@@ -17,16 +17,21 @@ class InvalidStorageValue(Exception):
 
 # see yellow paper section 9.4.3
 def valid_jump_destinations(code: bytes) -> set[int]:
-    from .opcodes import JUMPDEST, PUSH1, PUSH32
+    from .opcodes import REGISTRY, JUMPDEST, PUSH1, PUSH32
+
+    JUMPDEST_OPCODE = REGISTRY[JUMPDEST].opcode
+    PUSH1_OPCODE = REGISTRY[PUSH1].opcode
+    PUSH32_OPCODE = REGISTRY[PUSH32].opcode
 
     jumpdests = set()
     i = 0
     while i < len(code):
+
         current_op = code[i]
-        if current_op == JUMPDEST.opcode:
+        if current_op == JUMPDEST_OPCODE:
             jumpdests.add(i)
-        elif PUSH1.opcode <= current_op <= PUSH32.opcode:
-            i += current_op - PUSH1.opcode + 1
+        elif PUSH1_OPCODE <= current_op <= PUSH32_OPCODE:
+            i += current_op - PUSH1_OPCODE + 1
 
         i += 1
     return jumpdests

--- a/src/smol_evm/exceptions.py
+++ b/src/smol_evm/exceptions.py
@@ -9,11 +9,11 @@ class EVMException(Exception):
 
 
 @dataclass
-class UnknownOpcode(EVMException):
+class UnknownOpcode(Exception):
     opcode: int
 
     def __str__(self):
-        return f"opcode={hex(self.opcode)}, context={self.context}"
+        return f"opcode={hex(self.opcode)}"
 
 
 @dataclass

--- a/src/smol_evm/opcodes.py
+++ b/src/smol_evm/opcodes.py
@@ -1,7 +1,8 @@
+import functools
 import os
 
 from dataclasses import dataclass
-from typing import Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 from eth_utils import keccak
 
 from .context import ExecutionContext
@@ -28,25 +29,64 @@ class DuplicateOpcode(Exception):
     ...
 
 
-INSTRUCTIONS = [None] * 256
+class InstructionRegistry:
+    def __init__(self):
+        self.by_code = [None] * 256
+        self.by_name = {}
+        self.by_func = {}
+
+    def __getitem__(self, item: Union[int, str, object]) -> Instruction:
+        if isinstance(item, int):
+            retrieved = self.by_code[item]
+            if retrieved is None:
+                raise UnknownOpcode(item)
+            return retrieved
+
+        if isinstance(item, str):
+            return self.by_name[item]
+
+        if callable(item):
+            return self.by_func[item]
+
+    def __iter__(self):
+        return iter([i for i in self.by_code if i is not None])
+
+    def __len__(self):
+        return len(self.by_name)
+
+    def add(self, instruction: Instruction):
+        if self.by_code[instruction.opcode] is not None:
+            raise DuplicateOpcode({"opcode": instruction.opcode})
+
+        self.by_code[instruction.opcode] = instruction
+        self.by_name[instruction.name] = instruction
+        self.by_func[instruction.execute] = instruction
 
 
-def instruction(opcode: int, name: str, execute_func: callable):
+REGISTRY = InstructionRegistry()
+
+
+def instruction(opcode: int, name: str, func: Callable[[ExecutionContext], None]):
     instruction = Instruction(opcode, name)
-    instruction.execute = execute_func
+    instruction.execute = func
 
-    if INSTRUCTIONS[opcode] is not None:
-        raise DuplicateOpcode({"opcode": opcode})
-    INSTRUCTIONS[opcode] = instruction
+    REGISTRY.add(instruction)
 
     return instruction
 
 
-def _do_jump(ctx: ExecutionContext, target_pc: int) -> None:
-    if target_pc in ctx.jumpdests:
-        ctx.set_program_counter(target_pc)
-    else:
-        ctx.stop(success=False)
+# a decorator for * functions that registers them as instructions
+def insn(opcode: int, name: Optional[str] = None):
+    def decorator_insn(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        i = instruction(opcode, name or func.__name__, wrapped)
+
+        return wrapped
+
+    return decorator_insn
 
 
 def uint_to_int(n):
@@ -61,21 +101,62 @@ def int_to_uint(n):
     return n & MAX_UINT256
 
 
-def execute_JUMP(ctx: ExecutionContext) -> None:
-    _do_jump(ctx, ctx.stack.pop())
+
+@insn(0x00)
+def STOP(ctx: ExecutionContext) -> None:
+    ctx.stop(success=True)
 
 
-def execute_JUMPI(ctx: ExecutionContext) -> None:
-    target_pc, cond = ctx.stack.pop(), ctx.stack.pop()
-    if cond != 0:
-        _do_jump(ctx, target_pc)
+@insn(0x01)
+def ADD(ctx: ExecutionContext) -> None:
+    ctx.stack.push((ctx.stack.pop() + ctx.stack.pop()) & MAX_UINT256)
 
+@insn(0x02)
+def MUL(ctx: ExecutionContext) -> None:
+    ctx.stack.push((ctx.stack.pop() * ctx.stack.pop()) & MAX_UINT256)
 
-def execute_SUB(ctx: ExecutionContext) -> None:
+@insn(0x03)
+def SUB(ctx: ExecutionContext) -> None:
     a, b = ctx.stack.pop(), ctx.stack.pop()
     ctx.stack.push((a - b) & MAX_UINT256)
 
-def execute_SIGNEXTEND(ctx: ExecutionContext) -> None:
+@insn(0x04)
+def DIV(ctx: ExecutionContext) -> None:
+    a, b = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(a // b if b != 0 else 0)
+
+@insn(0x05)
+def SDIV(ctx: ExecutionContext) -> None:
+    a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
+    ctx.stack.push(int_to_uint(a // b) if b != 0 else 0)
+
+@insn(0x06)
+def MOD(ctx: ExecutionContext) -> None:
+    a, b = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(a % b if b != 0 else 0)
+
+@insn(0x07)
+def SMOD(ctx: ExecutionContext) -> None:
+    a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
+    ctx.stack.push(int_to_uint(a % b) if b != 0 else 0)
+
+@insn(0x08)
+def ADDMOD(ctx: ExecutionContext) -> None:
+    a, b, mod = ctx.stack.pop(), ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(((a + b) % mod) & MAX_UINT256)
+
+@insn(0x09)
+def MULMOD(ctx: ExecutionContext) -> None:
+    a, b, mod = ctx.stack.pop(), ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(((a * b) % mod) & MAX_UINT256)
+
+@insn(0x0A)
+def EXP(ctx: ExecutionContext) -> None:
+    a, exponent = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push((a ** exponent) & MAX_UINT256)
+
+@insn(0x0B)
+def SIGNEXTEND(ctx: ExecutionContext) -> None:
     a, b = ctx.stack.pop(), ctx.stack.pop() # a size in bytes, b int value
     # take rightmost <a+1> bytes of integer b
     b = b & ((1 << (a+1)*8) - 1)
@@ -91,361 +172,248 @@ def execute_SIGNEXTEND(ctx: ExecutionContext) -> None:
 
     ctx.stack.push(b)
 
-def execute_LT(ctx: ExecutionContext) -> None:
+@insn(0x10)
+def LT(ctx: ExecutionContext) -> None:
     a, b = ctx.stack.pop(), ctx.stack.pop()
     ctx.stack.push(1 if a < b else 0)
 
-
-def execute_GT(ctx: ExecutionContext) -> None:
+@insn(0x11)
+def GT(ctx: ExecutionContext) -> None:
     a, b = ctx.stack.pop(), ctx.stack.pop()
     ctx.stack.push(1 if a > b else 0)
 
-
-def execute_SLT(ctx: ExecutionContext) -> None:
+@insn(0x12)
+def SLT(ctx: ExecutionContext) -> None:
     a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
     ctx.stack.push(1 if a < b else 0)
 
-
-def execute_SGT(ctx: ExecutionContext) -> None:
+@insn(0x13)
+def SGT(ctx: ExecutionContext) -> None:
     a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
     ctx.stack.push(1 if a > b else 0)
 
+@insn(0x14)
+def EQ(ctx: ExecutionContext) -> None:
+    ctx.stack.push(1 if ctx.stack.pop() == ctx.stack.pop() else 0)
 
-def execute_BYTE(ctx: ExecutionContext) -> None:
+@insn(0x15)
+def ISZERO(ctx: ExecutionContext) -> None:
+    ctx.stack.push(1 if ctx.stack.pop() == 0 else 0)
+
+@insn(0x16)
+def AND(ctx: ExecutionContext) -> None:
+    ctx.stack.push((ctx.stack.pop() & ctx.stack.pop()))
+
+@insn(0x17)
+def OR(ctx: ExecutionContext) -> None:
+    ctx.stack.push((ctx.stack.pop() | ctx.stack.pop()))
+
+@insn(0x18)
+def XOR(ctx: ExecutionContext) -> None:
+    ctx.stack.push((ctx.stack.pop() ^ ctx.stack.pop()))
+
+@insn(0x19)
+def NOT(ctx: ExecutionContext) -> None:
+    ctx.stack.push(MAX_UINT256 ^ ctx.stack.pop())
+
+@insn(0x1A)
+def BYTE(ctx: ExecutionContext) -> None:
     offset, value = ctx.stack.pop(), ctx.stack.pop()
     if offset < 32:
         ctx.stack.push((value >> ((31 - offset) * 8)) & 0xFF)
     else:
         ctx.stack.push(0)
 
+@insn(0x1B)
+def SHL(ctx: ExecutionContext) -> None:
+    a, b = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(0 if a >= 256 else ((b << a) % 2 ** 256))
 
-def execute_SHA3(ctx: ExecutionContext) -> None:
+@insn(0x1C)
+def SHR(ctx: ExecutionContext) -> None:
+    a, b = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stack.push(b >> a)
+
+@insn(0x1D)
+def SAR(ctx: ExecutionContext) -> None:
+    shift, signed_value = ctx.stack.pop(), uint_to_int(ctx.stack.pop())
+    ctx.stack.push(int_to_uint(signed_value >> shift))
+
+@insn(0x20)
+def SHA3(ctx: ExecutionContext) -> None:
     offset, size = ctx.stack.pop(), ctx.stack.pop()
     content = ctx.memory.load_range(offset, size)
     ctx.stack.push(int.from_bytes(keccak(content), "big"))
 
+# TODO: placeholder for now
+@insn(0x34)
+def CALLVALUE(ctx: ExecutionContext) -> None:
+    ctx.stack.push(0)
 
-def execute_SHL(ctx: ExecutionContext) -> None:
-    a, b = ctx.stack.pop(), ctx.stack.pop()
-    ctx.stack.push(0 if a >= 256 else ((b << a) % 2 ** 256))
+@insn(0x35)
+def CALLDATALOAD(ctx: ExecutionContext) -> None:
+    ctx.stack.push(ctx.calldata.read_word(ctx.stack.pop()))
 
+@insn(0x36)
+def CALLDATASIZE(ctx: ExecutionContext) -> None:
+    ctx.stack.push(len(ctx.calldata))
 
-def execute_SHR(ctx: ExecutionContext) -> None:
-    a, b = ctx.stack.pop(), ctx.stack.pop()
-    ctx.stack.push(b >> a)
-
-
-def execute_SAR(ctx: ExecutionContext) -> None:
-    shift, signed_value = ctx.stack.pop(), uint_to_int(ctx.stack.pop())
-    ctx.stack.push(int_to_uint(signed_value >> shift))
-
-
-def execute_CALLDATACOPY(ctx: ExecutionContext) -> None:
+@insn(0x37)
+def CALLDATACOPY(ctx: ExecutionContext) -> None:
     dest_offset, offset, size = ctx.stack.pop(), ctx.stack.pop(), ctx.stack.pop()
     for pos in range((size / 32).__ceil__()):
         ctx.memory.store_word(
             dest_offset + pos * 32, ctx.calldata.read_word(offset + pos * 32)
         )
 
+@insn(0x50)
+def POP(ctx: ExecutionContext) -> None:
+    ctx.stack.pop()
 
-def execute_DIV(ctx: ExecutionContext) -> None:
-    a, b = ctx.stack.pop(), ctx.stack.pop()
-    ctx.stack.push(a // b if b != 0 else 0)
+@insn(0x51)
+def MLOAD(ctx: ExecutionContext) -> None:
+    ctx.stack.push(ctx.memory.load_word(ctx.stack.pop()))
+
+@insn(0x52)
+def MSTORE(ctx: ExecutionContext) -> None:
+    ctx.memory.store_word(offset=ctx.stack.pop(), value=ctx.stack.pop())
+
+@insn(0x53)
+def MSTORE8(ctx: ExecutionContext) -> None:
+    ctx.memory.store(offset=ctx.stack.pop(), value=ctx.stack.pop() % 256)
+
+@insn(0x54)
+def SLOAD(ctx: ExecutionContext) -> None:
+    ctx.stack.push(ctx.storage.get(slot=ctx.stack.pop()))
+
+@insn(0x55)
+def SSTORE(ctx: ExecutionContext) -> None:
+    ctx.storage.put(slot=ctx.stack.pop(), value=ctx.stack.pop())
 
 
-def execute_MOD(ctx: ExecutionContext) -> None:
-    a, b = ctx.stack.pop(), ctx.stack.pop()
-    ctx.stack.push(a % b if b != 0 else 0)
+def _do_jump(ctx: ExecutionContext, target_pc: int) -> None:
+    if target_pc in ctx.jumpdests:
+        ctx.set_program_counter(target_pc)
+    else:
+        ctx.stop(success=False)
 
+@insn(0x56)
+def JUMP(ctx: ExecutionContext) -> None:
+    _do_jump(ctx, ctx.stack.pop())
 
-def execute_SDIV(ctx: ExecutionContext) -> None:
-    a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
-    ctx.stack.push(int_to_uint(a // b) if b != 0 else 0)
+@insn(0x57)
+def JUMPI(ctx: ExecutionContext) -> None:
+    target_pc, cond = ctx.stack.pop(), ctx.stack.pop()
+    if cond != 0:
+        _do_jump(ctx, target_pc)
 
+@insn(0x58)
+def PC(ctx: ExecutionContext) -> None:
+    '''Get the value of the program counter prior to the increment corresponding to this instruction.'''
+    ctx.stack.push(ctx.pc - 1)
 
-def execute_SMOD(ctx: ExecutionContext) -> None:
-    a, b = uint_to_int(ctx.stack.pop()), uint_to_int(ctx.stack.pop())
-    ctx.stack.push(int_to_uint(a % b) if b != 0 else 0)
-
-
-STOP = instruction(0x00, "STOP", (lambda ctx: ctx.stop(success=True)))
-ADD = instruction(
-    0x01,
-    "ADD",
-    (lambda ctx: ctx.stack.push((ctx.stack.pop() + ctx.stack.pop()) & MAX_UINT256)),
-)
-MUL = instruction(
-    0x02,
-    "MUL",
-    (lambda ctx: ctx.stack.push((ctx.stack.pop() * ctx.stack.pop()) & MAX_UINT256)),
-)
-SUB = instruction(
-    0x03,
-    "SUB",
-    execute_SUB,
-)
-DIV = instruction(
-    0x04,
-    "DIV",
-    execute_DIV,
-)
-SDIV = instruction(
-    0x05,
-    "SDIV",
-    execute_SDIV,
-)
-
-MOD = instruction(
-    0x06,
-    "MOD",
-    execute_MOD,
-)
-
-SMOD = instruction(
-    0x07,
-    "SMOD",
-    execute_SMOD,
-)
-
-ADDMOD = instruction(
-    0x08,
-    "ADDMOD",
-    (
-        lambda ctx: ctx.stack.push(
-            ((ctx.stack.pop() + ctx.stack.pop()) % ctx.stack.pop()) & MAX_UINT256
-        )
-    ),
-)
-
-MULMOD = instruction(
-    0x09,
-    "MULMOD",
-    (
-        lambda ctx: ctx.stack.push(
-            ((ctx.stack.pop() * ctx.stack.pop()) % ctx.stack.pop()) & MAX_UINT256
-        )
-    ),
-)
-
-EXP = instruction(
-    0x0A,
-    "EXP",
-    (lambda ctx: ctx.stack.push((ctx.stack.pop() ** ctx.stack.pop()) & MAX_UINT256)),
-)
-
-SIGNEXTEND = instruction(0x0B, "SIGNEXTEND", execute_SIGNEXTEND)
-
-LT = instruction(0x10, "LT", execute_LT)
-GT = instruction(0x11, "GT", execute_GT)
-SLT = instruction(0x12, "SLT", execute_SLT)
-SGT = instruction(0x13, "SGT", execute_SGT)
-EQ = instruction(
-    0x14,
-    "EQ",
-    lambda ctx: ctx.stack.push(1 if ctx.stack.pop() == ctx.stack.pop() else 0),
-)
-ISZERO = instruction(
-    0x15,
-    "ISZERO",
-    lambda ctx: ctx.stack.push(1 if ctx.stack.pop() == 0 else 0),
-)
-AND = instruction(
-    0x16, "AND", (lambda ctx: ctx.stack.push((ctx.stack.pop() & ctx.stack.pop())))
-)
-OR = instruction(
-    0x17, "OR", (lambda ctx: ctx.stack.push((ctx.stack.pop() | ctx.stack.pop())))
-)
-XOR = instruction(
-    0x18, "XOR", (lambda ctx: ctx.stack.push((ctx.stack.pop() ^ ctx.stack.pop())))
-)
-NOT = instruction(
-    0x19, "NOT", (lambda ctx: ctx.stack.push(MAX_UINT256 ^ ctx.stack.pop()))
-)
-BYTE = instruction(0x1A, "BYTE", execute_BYTE)
-SHL = instruction(
-    0x1B,
-    "SHL",
-    execute_SHL,
-)
-SHR = instruction(
-    0x1C,
-    "SHR",
-    execute_SHR,
-)
-SAR = instruction(
-    0x1D,
-    "SAR",
-    execute_SAR,
-)
-SHA3 = instruction(0x20, "SHA3", execute_SHA3)
+@insn(0x59)
+def MSIZE(ctx: ExecutionContext) -> None:
+    ctx.stack.push(32 * ctx.memory.active_words())
 
 # TODO: placeholder for now
-CALLVALUE = instruction(
-    0x34,
-    "CALLVALUE",
-    lambda ctx: ctx.stack.push(0),
-)
-CALLDATALOAD = instruction(
-    0x35,
-    "CALLDATALOAD",
-    lambda ctx: ctx.stack.push(ctx.calldata.read_word(ctx.stack.pop())),
-)
-CALLDATASIZE = instruction(
-    0x36,
-    "CALLDATASIZE",
-    lambda ctx: ctx.stack.push(len(ctx.calldata)),
-)
-CALLDATACOPY = instruction(
-    0x37,
-    "CALLDATACOPY",
-    execute_CALLDATACOPY,
-)
-POP = instruction(
-    0x50,
-    "POP",
-    lambda ctx: ctx.stack.pop(),
-)
-MLOAD = instruction(
-    0x51,
-    "MLOAD",
-    (lambda ctx: ctx.stack.push(ctx.memory.load_word(ctx.stack.pop()))),
-)
-MSTORE = instruction(
-    0x52,
-    "MSTORE",
-    (lambda ctx: ctx.memory.store_word(ctx.stack.pop(), ctx.stack.pop())),
-)
-MSTORE8 = instruction(
-    0x53,
-    "MSTORE8",
-    (lambda ctx: ctx.memory.store(ctx.stack.pop(), ctx.stack.pop() % 256)),
-)
-SLOAD = instruction(
-    0x54,
-    "SLOAD",
-    (lambda ctx: ctx.stack.push(ctx.storage.get(ctx.stack.pop()))),
-)
-SSTORE = instruction(
-    0x55,
-    "SSTORE",
-    (lambda ctx: ctx.storage.put(ctx.stack.pop(), ctx.stack.pop())),
-)
-JUMP = instruction(
-    0x56,
-    "JUMP",
-    execute_JUMP,
-)
-JUMPI = instruction(
-    0x57,
-    "JUMPI",
-    execute_JUMPI,
-)
-PC = instruction(
-    0x58,
-    "PC",
-    # Get the value of the program counter prior to the increment corresponding to this instruction
-    (lambda ctx: ctx.stack.push(ctx.pc - 1)),
-)
-MSIZE = instruction(
-    0x59,
-    "MSIZE",
-    (lambda ctx: ctx.stack.push(32 * ctx.memory.active_words())),
-)
-GAS = instruction(
-    0x5A,
-    "GAS",
-    # Get the amount of available gas, including the corresponding reduction for the cost of this instruction.
-    # TODO: placeholder for now
-    (lambda ctx: ctx.stack.push(MAX_UINT256)),
-)
-JUMPDEST = instruction(
-    0x5B,
-    "JUMPDEST",
-    # This operation has no effect on machine state during execution.
-    (lambda ctx: ctx),
-)
+@insn(0x5A)
+def GAS(ctx: ExecutionContext) -> None:
+    '''Get the amount of available gas, including the corresponding reduction for the cost of this instruction.'''
+    ctx.stack.push(MAX_UINT256)
 
-PUSH1 = instruction(0x60, "PUSH1", lambda ctx: ctx.stack.push(ctx.read_code(1)))
-PUSH2 = instruction(0x61, "PUSH2", lambda ctx: ctx.stack.push(ctx.read_code(2)))
-PUSH3 = instruction(0x62, "PUSH3", lambda ctx: ctx.stack.push(ctx.read_code(3)))
-PUSH4 = instruction(0x63, "PUSH4", lambda ctx: ctx.stack.push(ctx.read_code(4)))
-PUSH5 = instruction(0x64, "PUSH5", lambda ctx: ctx.stack.push(ctx.read_code(5)))
-PUSH6 = instruction(0x65, "PUSH6", lambda ctx: ctx.stack.push(ctx.read_code(6)))
-PUSH7 = instruction(0x66, "PUSH7", lambda ctx: ctx.stack.push(ctx.read_code(7)))
-PUSH8 = instruction(0x67, "PUSH8", lambda ctx: ctx.stack.push(ctx.read_code(8)))
-PUSH9 = instruction(0x68, "PUSH9", lambda ctx: ctx.stack.push(ctx.read_code(9)))
-PUSH10 = instruction(0x69, "PUSH10", lambda ctx: ctx.stack.push(ctx.read_code(10)))
-PUSH11 = instruction(0x6A, "PUSH11", lambda ctx: ctx.stack.push(ctx.read_code(11)))
-PUSH12 = instruction(0x6B, "PUSH12", lambda ctx: ctx.stack.push(ctx.read_code(12)))
-PUSH13 = instruction(0x6C, "PUSH13", lambda ctx: ctx.stack.push(ctx.read_code(13)))
-PUSH14 = instruction(0x6D, "PUSH14", lambda ctx: ctx.stack.push(ctx.read_code(14)))
-PUSH15 = instruction(0x6E, "PUSH15", lambda ctx: ctx.stack.push(ctx.read_code(15)))
-PUSH16 = instruction(0x6F, "PUSH16", lambda ctx: ctx.stack.push(ctx.read_code(16)))
-PUSH17 = instruction(0x70, "PUSH17", lambda ctx: ctx.stack.push(ctx.read_code(17)))
-PUSH18 = instruction(0x71, "PUSH18", lambda ctx: ctx.stack.push(ctx.read_code(18)))
-PUSH19 = instruction(0x72, "PUSH19", lambda ctx: ctx.stack.push(ctx.read_code(19)))
-PUSH20 = instruction(0x73, "PUSH20", lambda ctx: ctx.stack.push(ctx.read_code(20)))
-PUSH21 = instruction(0x74, "PUSH21", lambda ctx: ctx.stack.push(ctx.read_code(21)))
-PUSH22 = instruction(0x75, "PUSH22", lambda ctx: ctx.stack.push(ctx.read_code(22)))
-PUSH23 = instruction(0x76, "PUSH23", lambda ctx: ctx.stack.push(ctx.read_code(23)))
-PUSH24 = instruction(0x77, "PUSH24", lambda ctx: ctx.stack.push(ctx.read_code(24)))
-PUSH25 = instruction(0x78, "PUSH25", lambda ctx: ctx.stack.push(ctx.read_code(25)))
-PUSH26 = instruction(0x79, "PUSH26", lambda ctx: ctx.stack.push(ctx.read_code(26)))
-PUSH27 = instruction(0x7A, "PUSH27", lambda ctx: ctx.stack.push(ctx.read_code(27)))
-PUSH28 = instruction(0x7B, "PUSH28", lambda ctx: ctx.stack.push(ctx.read_code(28)))
-PUSH29 = instruction(0x7C, "PUSH29", lambda ctx: ctx.stack.push(ctx.read_code(29)))
-PUSH30 = instruction(0x7D, "PUSH30", lambda ctx: ctx.stack.push(ctx.read_code(30)))
-PUSH31 = instruction(0x7E, "PUSH31", lambda ctx: ctx.stack.push(ctx.read_code(31)))
-PUSH32 = instruction(0x7F, "PUSH32", lambda ctx: ctx.stack.push(ctx.read_code(32)))
+@insn(0x5B)
+def JUMPDEST(ctx: ExecutionContext) -> None:
+    '''Mark a valid destination for jumps. This operation has no effect on machine state during execution.'''
+    pass
 
-DUP1 = instruction(0x80, "DUP1", lambda ctx: ctx.stack.push(ctx.stack.peek(0)))
-DUP2 = instruction(0x81, "DUP2", lambda ctx: ctx.stack.push(ctx.stack.peek(1)))
-DUP3 = instruction(0x82, "DUP3", lambda ctx: ctx.stack.push(ctx.stack.peek(2)))
-DUP4 = instruction(0x83, "DUP4", lambda ctx: ctx.stack.push(ctx.stack.peek(3)))
-DUP5 = instruction(0x84, "DUP5", lambda ctx: ctx.stack.push(ctx.stack.peek(4)))
-DUP6 = instruction(0x85, "DUP6", lambda ctx: ctx.stack.push(ctx.stack.peek(5)))
-DUP7 = instruction(0x86, "DUP7", lambda ctx: ctx.stack.push(ctx.stack.peek(6)))
-DUP8 = instruction(0x87, "DUP8", lambda ctx: ctx.stack.push(ctx.stack.peek(7)))
-DUP9 = instruction(0x88, "DUP9", lambda ctx: ctx.stack.push(ctx.stack.peek(8)))
-DUP10 = instruction(0x89, "DUP10", lambda ctx: ctx.stack.push(ctx.stack.peek(9)))
-DUP11 = instruction(0x8A, "DUP11", lambda ctx: ctx.stack.push(ctx.stack.peek(10)))
-DUP12 = instruction(0x8B, "DUP12", lambda ctx: ctx.stack.push(ctx.stack.peek(11)))
-DUP13 = instruction(0x8C, "DUP13", lambda ctx: ctx.stack.push(ctx.stack.peek(12)))
-DUP14 = instruction(0x8D, "DUP14", lambda ctx: ctx.stack.push(ctx.stack.peek(13)))
-DUP15 = instruction(0x8E, "DUP15", lambda ctx: ctx.stack.push(ctx.stack.peek(14)))
-DUP16 = instruction(0x8F, "DUP16", lambda ctx: ctx.stack.push(ctx.stack.peek(15)))
+PUSH1 = insn(0x60, 'PUSH1')(lambda ctx: ctx.stack.push(ctx.read_code(1)))
+PUSH2 = insn(0x61, 'PUSH2')(lambda ctx: ctx.stack.push(ctx.read_code(2)))
+PUSH3 = insn(0x62, 'PUSH3')(lambda ctx: ctx.stack.push(ctx.read_code(3)))
+PUSH4 = insn(0x63, 'PUSH4')(lambda ctx: ctx.stack.push(ctx.read_code(4)))
+PUSH5 = insn(0x64, 'PUSH5')(lambda ctx: ctx.stack.push(ctx.read_code(5)))
+PUSH6 = insn(0x65, 'PUSH6')(lambda ctx: ctx.stack.push(ctx.read_code(6)))
+PUSH7 = insn(0x66, 'PUSH7')(lambda ctx: ctx.stack.push(ctx.read_code(7)))
+PUSH8 = insn(0x67, 'PUSH8')(lambda ctx: ctx.stack.push(ctx.read_code(8)))
+PUSH9 = insn(0x68, 'PUSH9')(lambda ctx: ctx.stack.push(ctx.read_code(9)))
+PUSH10 = insn(0x69, 'PUSH10')(lambda ctx: ctx.stack.push(ctx.read_code(10)))
+PUSH11 = insn(0x6A, 'PUSH11')(lambda ctx: ctx.stack.push(ctx.read_code(11)))
+PUSH12 = insn(0x6B, 'PUSH12')(lambda ctx: ctx.stack.push(ctx.read_code(12)))
+PUSH13 = insn(0x6C, 'PUSH13')(lambda ctx: ctx.stack.push(ctx.read_code(13)))
+PUSH14 = insn(0x6D, 'PUSH14')(lambda ctx: ctx.stack.push(ctx.read_code(14)))
+PUSH15 = insn(0x6E, 'PUSH15')(lambda ctx: ctx.stack.push(ctx.read_code(15)))
+PUSH16 = insn(0x6F, 'PUSH16')(lambda ctx: ctx.stack.push(ctx.read_code(16)))
+PUSH17 = insn(0x70, 'PUSH17')(lambda ctx: ctx.stack.push(ctx.read_code(17)))
+PUSH18 = insn(0x71, 'PUSH18')(lambda ctx: ctx.stack.push(ctx.read_code(18)))
+PUSH19 = insn(0x72, 'PUSH19')(lambda ctx: ctx.stack.push(ctx.read_code(19)))
+PUSH20 = insn(0x73, 'PUSH20')(lambda ctx: ctx.stack.push(ctx.read_code(20)))
+PUSH21 = insn(0x74, 'PUSH21')(lambda ctx: ctx.stack.push(ctx.read_code(21)))
+PUSH22 = insn(0x75, 'PUSH22')(lambda ctx: ctx.stack.push(ctx.read_code(22)))
+PUSH23 = insn(0x76, 'PUSH23')(lambda ctx: ctx.stack.push(ctx.read_code(23)))
+PUSH24 = insn(0x77, 'PUSH24')(lambda ctx: ctx.stack.push(ctx.read_code(24)))
+PUSH25 = insn(0x78, 'PUSH25')(lambda ctx: ctx.stack.push(ctx.read_code(25)))
+PUSH26 = insn(0x79, 'PUSH26')(lambda ctx: ctx.stack.push(ctx.read_code(26)))
+PUSH27 = insn(0x7A, 'PUSH27')(lambda ctx: ctx.stack.push(ctx.read_code(27)))
+PUSH28 = insn(0x7B, 'PUSH28')(lambda ctx: ctx.stack.push(ctx.read_code(28)))
+PUSH29 = insn(0x7C, 'PUSH29')(lambda ctx: ctx.stack.push(ctx.read_code(29)))
+PUSH30 = insn(0x7D, 'PUSH30')(lambda ctx: ctx.stack.push(ctx.read_code(30)))
+PUSH31 = insn(0x7E, 'PUSH31')(lambda ctx: ctx.stack.push(ctx.read_code(31)))
+PUSH32 = insn(0x7F, 'PUSH32')(lambda ctx: ctx.stack.push(ctx.read_code(32)))
 
-SWAP1 = instruction(0x90, "SWAP1", lambda ctx: ctx.stack.swap(1))
-SWAP2 = instruction(0x91, "SWAP2", lambda ctx: ctx.stack.swap(2))
-SWAP3 = instruction(0x92, "SWAP3", lambda ctx: ctx.stack.swap(3))
-SWAP4 = instruction(0x93, "SWAP4", lambda ctx: ctx.stack.swap(4))
-SWAP5 = instruction(0x94, "SWAP5", lambda ctx: ctx.stack.swap(5))
-SWAP6 = instruction(0x95, "SWAP6", lambda ctx: ctx.stack.swap(6))
-SWAP7 = instruction(0x96, "SWAP7", lambda ctx: ctx.stack.swap(7))
-SWAP8 = instruction(0x97, "SWAP8", lambda ctx: ctx.stack.swap(8))
-SWAP9 = instruction(0x98, "SWAP9", lambda ctx: ctx.stack.swap(9))
-SWAP10 = instruction(0x99, "SWAP10", lambda ctx: ctx.stack.swap(10))
-SWAP11 = instruction(0x9A, "SWAP11", lambda ctx: ctx.stack.swap(11))
-SWAP12 = instruction(0x9B, "SWAP12", lambda ctx: ctx.stack.swap(12))
-SWAP13 = instruction(0x9C, "SWAP13", lambda ctx: ctx.stack.swap(13))
-SWAP14 = instruction(0x9D, "SWAP14", lambda ctx: ctx.stack.swap(14))
-SWAP15 = instruction(0x9E, "SWAP15", lambda ctx: ctx.stack.swap(15))
-SWAP16 = instruction(0x9F, "SWAP16", lambda ctx: ctx.stack.swap(16))
+DUP1 = insn(0x80, "DUP1")(lambda ctx: ctx.stack.push(ctx.stack.peek(0)))
+DUP2 = insn(0x81, "DUP2")(lambda ctx: ctx.stack.push(ctx.stack.peek(1)))
+DUP3 = insn(0x82, "DUP3")(lambda ctx: ctx.stack.push(ctx.stack.peek(2)))
+DUP4 = insn(0x83, "DUP4")(lambda ctx: ctx.stack.push(ctx.stack.peek(3)))
+DUP5 = insn(0x84, "DUP5")(lambda ctx: ctx.stack.push(ctx.stack.peek(4)))
+DUP6 = insn(0x85, "DUP6")(lambda ctx: ctx.stack.push(ctx.stack.peek(5)))
+DUP7 = insn(0x86, "DUP7")(lambda ctx: ctx.stack.push(ctx.stack.peek(6)))
+DUP8 = insn(0x87, "DUP8")(lambda ctx: ctx.stack.push(ctx.stack.peek(7)))
+DUP9 = insn(0x88, "DUP9")(lambda ctx: ctx.stack.push(ctx.stack.peek(8)))
+DUP10 = insn(0x89, "DUP10")(lambda ctx: ctx.stack.push(ctx.stack.peek(9)))
+DUP11 = insn(0x8A, "DUP11")(lambda ctx: ctx.stack.push(ctx.stack.peek(10)))
+DUP12 = insn(0x8B, "DUP12")(lambda ctx: ctx.stack.push(ctx.stack.peek(11)))
+DUP13 = insn(0x8C, "DUP13")(lambda ctx: ctx.stack.push(ctx.stack.peek(12)))
+DUP14 = insn(0x8D, "DUP14")(lambda ctx: ctx.stack.push(ctx.stack.peek(13)))
+DUP15 = insn(0x8E, "DUP15")(lambda ctx: ctx.stack.push(ctx.stack.peek(14)))
+DUP16 = insn(0x8F, "DUP16")(lambda ctx: ctx.stack.push(ctx.stack.peek(15)))
 
-RETURN = instruction(
-    0xF3,
-    "RETURN",
-    (lambda ctx: ctx.set_return_data(ctx.stack.pop(), ctx.stack.pop())),
-)
+SWAP1 = insn(0x90, "SWAP1")(lambda ctx: ctx.stack.swap(1))
+SWAP2 = insn(0x91, "SWAP2")(lambda ctx: ctx.stack.swap(2))
+SWAP3 = insn(0x92, "SWAP3")(lambda ctx: ctx.stack.swap(3))
+SWAP4 = insn(0x93, "SWAP4")(lambda ctx: ctx.stack.swap(4))
+SWAP5 = insn(0x94, "SWAP5")(lambda ctx: ctx.stack.swap(5))
+SWAP6 = insn(0x95, "SWAP6")(lambda ctx: ctx.stack.swap(6))
+SWAP7 = insn(0x96, "SWAP7")(lambda ctx: ctx.stack.swap(7))
+SWAP8 = insn(0x97, "SWAP8")(lambda ctx: ctx.stack.swap(8))
+SWAP9 = insn(0x98, "SWAP9")(lambda ctx: ctx.stack.swap(9))
+SWAP10 = insn(0x99, "SWAP10")(lambda ctx: ctx.stack.swap(10))
+SWAP11 = insn(0x9A, "SWAP11")(lambda ctx: ctx.stack.swap(11))
+SWAP12 = insn(0x9B, "SWAP12")(lambda ctx: ctx.stack.swap(12))
+SWAP13 = insn(0x9C, "SWAP13")(lambda ctx: ctx.stack.swap(13))
+SWAP14 = insn(0x9D, "SWAP14")(lambda ctx: ctx.stack.swap(14))
+SWAP15 = insn(0x9E, "SWAP15")(lambda ctx: ctx.stack.swap(15))
+SWAP16 = insn(0x9F, "SWAP16")(lambda ctx: ctx.stack.swap(16))
+
+@insn(0xF3)
+def RETURN(ctx: ExecutionContext) -> None:
+    offset, length = ctx.stack.pop(), ctx.stack.pop()
+    ctx.set_return_data(offset, length)
+    ctx.stop(success=True)
 
 # TODO: no-op for now
-REVERT = instruction(0xFD, "REVERT", (lambda ctx: ctx.stop(success=False)))
+@insn(0xFD)
+def REVERT(ctx: ExecutionContext) -> None:
+    offset, length = ctx.stack.pop(), ctx.stack.pop()
+    ctx.stop(success=False)
 
 # TODO: no-op for now. Equivalent to REVERT(0, 0) but consumes all available gas
-INVALID = instruction(0xFE, "INVALID", (lambda ctx: ctx.stop(success=False)))
+@insn(0xFE)
+def INVALID(ctx: ExecutionContext) -> None:
+    ctx.stop(success=False)
 
 if os.getenv("DEBUG"):
-    print(f"📈 {len([x for x in INSTRUCTIONS if x is not None])} instructions completed")
+    print(f"📈 {len(REGISTRY)} instructions completed")
+    print(REGISTRY.by_code)
 
 def decode_opcode(context: ExecutionContext) -> Instruction:
     if context.pc < 0:
@@ -453,13 +421,13 @@ def decode_opcode(context: ExecutionContext) -> Instruction:
 
     # section 9.4.1 of the yellow paper, if pc is outside code, then the operation to be executed is STOP
     if context.pc >= len(context.code):
-        return STOP
+        return REGISTRY[STOP]
 
     # increments context.pc
     opcode = context.read_code(1)
-    instruction = INSTRUCTIONS[opcode]
+    instruction = REGISTRY[opcode]
     if instruction is None:
-        raise UnknownOpcode(opcode=opcode, context=context)
+        raise UnknownOpcode(opcode=opcode)
 
     return instruction
 
@@ -471,6 +439,9 @@ def assemble(instructions: Sequence[Union[Instruction, int]], print_bin=True) ->
             result += bytes([item.opcode])
         elif isinstance(item, int):
             result += int_to_bytes(item)
+        elif callable(item):
+            _instruction = REGISTRY[item]
+            result += bytes([_instruction.opcode])
         else:
             raise TypeError(f"Unexpected {type(item)} in {instructions}")
 

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,20 +1,6 @@
 from smol_evm.constants import MAX_UINT256
 from smol_evm.context import ExecutionContext
-from smol_evm.opcodes import (
-    ADD,
-    ADDMOD,
-    DIV,
-    SDIV,
-    EXP,
-    MOD,
-    SMOD,
-    MULMOD,
-    SAR,
-    SIGNEXTEND,
-    SUB,
-    int_to_uint,
-    uint_to_int,
-)
+from smol_evm.opcodes import *
 
 import pytest
 
@@ -27,201 +13,201 @@ def context() -> ExecutionContext:
 
 
 def test_add_simple(context):
-    ADD.execute(with_stack(context, [1, 2]))
+    ADD(with_stack(context, [1, 2]))
     assert context.stack.pop() == 3
 
 
 def test_add_overflow(context):
-    ADD.execute(with_stack(context, [1, MAX_UINT256]))
+    ADD(with_stack(context, [1, MAX_UINT256]))
     assert context.stack.pop() == 0
 
 
 def test_add_overflow2(context):
-    ADD.execute(with_stack(context, [3, MAX_UINT256 - 1]))
+    ADD(with_stack(context, [3, MAX_UINT256 - 1]))
     assert context.stack.pop() == 1
 
 
 def test_sub_simple(context):
-    SUB.execute(with_stack(context, [2, 3]))
+    SUB(with_stack(context, [2, 3]))
     assert context.stack.pop() == 1
 
 
 def test_sub_underflow(context):
-    SUB.execute(with_stack(context, [2, 1]))
+    SUB(with_stack(context, [2, 1]))
     assert context.stack.pop() == MAX_UINT256
 
 
 def test_sub_EXTREME(context):
-    SUB.execute(with_stack(context, [MAX_UINT256, MAX_UINT256]))
+    SUB(with_stack(context, [MAX_UINT256, MAX_UINT256]))
     assert context.stack.pop() == 0
 
 
 def test_div_simple(context):
-    DIV.execute(with_stack(context, [2, 10]))
+    DIV(with_stack(context, [2, 10]))
     assert context.stack.pop() == 5
 
 
 def test_div_floor(context):
-    DIV.execute(with_stack(context, [2, 11]))
+    DIV(with_stack(context, [2, 11]))
     assert context.stack.pop() == 5
 
 
 def test_div_EXTREME(context):
-    DIV.execute(with_stack(context, [MAX_UINT256, MAX_UINT256]))
+    DIV(with_stack(context, [MAX_UINT256, MAX_UINT256]))
     assert context.stack.pop() == 1
 
 
 def test_div_zero(context):
-    DIV.execute(with_stack(context, [MAX_UINT256, 0]))
+    DIV(with_stack(context, [MAX_UINT256, 0]))
     assert context.stack.pop() == 0
 
 
 def test_div_by_zero(context):
-    DIV.execute(with_stack(context, [0, 1]))
+    DIV(with_stack(context, [0, 1]))
     assert context.stack.pop() == 0
 
 
 def test_sdiv_simple(context):
     # NOTE: int(MAX_UINT256) is -1
     # 20 / -2
-    SDIV.execute(with_stack(context, [int_to_uint(-2), 20]))
+    SDIV(with_stack(context, [int_to_uint(-2), 20]))
     assert context.stack.pop() == int_to_uint(-10)
 
 
 def test_sdiv_floor(context):
     # -11 / -2
-    SDIV.execute(with_stack(context, [int_to_uint(-2), int_to_uint(-11)]))
+    SDIV(with_stack(context, [int_to_uint(-2), int_to_uint(-11)]))
     assert context.stack.pop() == 5
 
 
 def test_sdiv_EXTREME(context):
     # -1 / 1
-    SDIV.execute(with_stack(context, [1, MAX_UINT256]))
+    SDIV(with_stack(context, [1, MAX_UINT256]))
     assert context.stack.pop() == int_to_uint(-1)
 
 
 def test_sdiv_zero(context):
     # 0 / -1
-    SDIV.execute(with_stack(context, [MAX_UINT256, 0]))
+    SDIV(with_stack(context, [MAX_UINT256, 0]))
     assert context.stack.pop() == 0
 
 
 def test_sdiv_by_zero(context):
     # -1 / 0
-    SDIV.execute(with_stack(context, [0, int_to_uint(-11)]))
+    SDIV(with_stack(context, [0, int_to_uint(-11)]))
     assert context.stack.pop() == 0
 
 
 def test_mod_simple(context):
-    MOD.execute(with_stack(context, [2, 11]))
+    MOD(with_stack(context, [2, 11]))
     assert context.stack.pop() == 1
 
 
 def test_mod_zero(context):
     # 0 mod 11
-    MOD.execute(with_stack(context, [11, 0]))
+    MOD(with_stack(context, [11, 0]))
     assert context.stack.pop() == 0
 
 
 def test_mod_by_zero(context):
     # 1 mod 0
-    MOD.execute(with_stack(context, [0, 1]))
+    MOD(with_stack(context, [0, 1]))
     assert context.stack.pop() == 0
 
 
 def test_mod_EXTREME(context):
-    MOD.execute(with_stack(context, [MAX_UINT256, MAX_UINT256]))
+    MOD(with_stack(context, [MAX_UINT256, MAX_UINT256]))
     assert context.stack.pop() == 0
 
 
 def test_smod_simple(context):
     # 11 % -2
-    SMOD.execute(with_stack(context, [int_to_uint(-2), 11]))
+    SMOD(with_stack(context, [int_to_uint(-2), 11]))
     assert context.stack.pop() == int_to_uint(-1)
 
 
 def test_smod_zero(context):
     # 0 % -11
-    SMOD.execute(with_stack(context, [int_to_uint(-11), 0]))
+    SMOD(with_stack(context, [int_to_uint(-11), 0]))
     assert context.stack.pop() == 0
 
 
 def test_smod_by_zero(context):
     # -1 % 0
-    SMOD.execute(with_stack(context, [0, int_to_uint(-1)]))
+    SMOD(with_stack(context, [0, int_to_uint(-1)]))
     assert context.stack.pop() == 0
 
 
 def test_smod_EXTREME(context):
     # -1 % -1 == 0
-    SMOD.execute(with_stack(context, [MAX_UINT256, MAX_UINT256]))
+    SMOD(with_stack(context, [MAX_UINT256, MAX_UINT256]))
     assert context.stack.pop() == 0
 
 
 def test_addmod_simple(context):
-    ADDMOD.execute(with_stack(context, [2, 4, 3]))
+    ADDMOD(with_stack(context, [2, 4, 3]))
     assert context.stack.pop() == 1
 
 
 def test_mulmod_simple(context):
-    MULMOD.execute(with_stack(context, [2, 4, 3]))
+    MULMOD(with_stack(context, [2, 4, 3]))
     assert context.stack.pop() == 0
 
 
 def test_exp_simple(context):
-    EXP.execute(with_stack(context, [2, 10]))
+    EXP(with_stack(context, [2, 10]))
     assert context.stack.pop() == 100
 
 
 def test_exp_overflow(context):
-    EXP.execute(with_stack(context, [2, MAX_UINT256 - 1]))
+    EXP(with_stack(context, [2, MAX_UINT256 - 1]))
     assert context.stack.pop() < MAX_UINT256
 
 
 def test_signextend_simple(context):
-    SIGNEXTEND.execute(with_stack(context, [0xFF, 0]))
+    SIGNEXTEND(with_stack(context, [0xFF, 0]))
     assert context.stack.pop() == MAX_UINT256
 
-    SIGNEXTEND.execute(with_stack(context, [0x7F, 0]))
+    SIGNEXTEND(with_stack(context, [0x7F, 0]))
     assert context.stack.pop() == 0x7F
 
-    SIGNEXTEND.execute(with_stack(context, [0xABCD, 1]))
+    SIGNEXTEND(with_stack(context, [0xABCD, 1]))
     assert context.stack.pop() == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFABCD
 
-    SIGNEXTEND.execute(with_stack(context, [0x1234, 1]))
+    SIGNEXTEND(with_stack(context, [0x1234, 1]))
     assert context.stack.pop() == 0x1234
 
 
 def test_signextend_EXTREME(context):
-    SIGNEXTEND.execute(with_stack(context, [0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFAABB, 100]))
+    SIGNEXTEND(with_stack(context, [0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFAABB, 100]))
     assert context.stack.pop() == 0x1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFAABB
 
 
 def test_sar_signed_normal(context):
-    SAR.execute(with_stack(context, [int_to_uint(-4), 2]))
+    SAR(with_stack(context, [int_to_uint(-4), 2]))
     assert context.stack.pop() == int_to_uint(-1)
 
 
 def test_sar_signed_big(context):
-    SAR.execute(with_stack(context, [0x8000000000000000000000000000000000000000000000000000000000000000, 1]))
+    SAR(with_stack(context, [0x8000000000000000000000000000000000000000000000000000000000000000, 1]))
     assert context.stack.pop() == 0xC000000000000000000000000000000000000000000000000000000000000000
 
 
 def test_sar_massive_shift(context):
-    SAR.execute(with_stack(context, [int_to_uint(-256), 0xFFFFFFFF]))
+    SAR(with_stack(context, [int_to_uint(-256), 0xFFFFFFFF]))
     assert context.stack.pop() == int_to_uint(-1)
 
 
 def test_sar_unsigned_normal(context):
-    SAR.execute(with_stack(context, [4, 1]))
+    SAR(with_stack(context, [4, 1]))
     assert context.stack.pop() == 2
 
 
 def test_sar_unsigned_big(context):
-    SAR.execute(with_stack(context, [0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1]))
+    SAR(with_stack(context, [0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, 1]))
     assert context.stack.pop() == 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 
 
 def test_sar_by_zero(context):
-    SAR.execute(with_stack(context, [1, 0]))
+    SAR(with_stack(context, [1, 0]))
     assert context.stack.pop() == 1

--- a/tests/test_bitwise.py
+++ b/tests/test_bitwise.py
@@ -12,107 +12,103 @@ def context() -> ExecutionContext:
 
 
 def test_or_simple(context):
-    OR.execute(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
+    OR(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
     assert context.stack.pop() == int("0xFF",16)
 
 
 def test_and_simple(context):
-    AND.execute(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
+    AND(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
     assert context.stack.pop() == int("0x10",16)
 
 
 def test_xor_simple(context):
-    XOR.execute(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
+    XOR(with_stack(context,[int("0x1F",16),int("0xF0",16)]))
     assert context.stack.pop() == int("0xEF",16)
 
 
 def test_not_simple(context):
-    NOT.execute(with_stack(context, [1]))
+    NOT(with_stack(context, [1]))
     assert context.stack.pop() == int("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",16)
 
 
 def test_shl_simple(context):
-    SHL.execute(with_stack(context, [16, 1]))
+    SHL(with_stack(context, [16, 1]))
     assert context.stack.pop() == 32
 
 
 def test_shl_big(context):
-    SHL.execute(with_stack(context, [16, 5]))
+    SHL(with_stack(context, [16, 5]))
     assert context.stack.pop() == 512
 
 
 def test_shl_by_zero(context):
-    SHL.execute(with_stack(context, [16, 0]))
+    SHL(with_stack(context, [16, 0]))
     assert context.stack.pop() == 16
 
 
 def test_shl_non_power_of_two(context):
-    SHL.execute(with_stack(context, [15, 1]))
+    SHL(with_stack(context, [15, 1]))
     assert context.stack.pop() == 30
 
 
 def test_shl_max(context):
-    SHL.execute(with_stack(context, [2 ** 256 - 1, 1]))
+    SHL(with_stack(context, [2 ** 256 - 1, 1]))
     assert context.stack.pop() == (2 ** 256 - 1) - 1
 
 
 def test_shl_by_max(context):
-    SHL.execute(with_stack(context, [2 ** 256 - 1, 2 ** 256 - 1]))
+    SHL(with_stack(context, [2 ** 256 - 1, 2 ** 256 - 1]))
     assert context.stack.pop() == 0
 
 
 def test_shr_simple(context):
-    SHR.execute(with_stack(context, [16, 1]))
+    SHR(with_stack(context, [16, 1]))
     assert context.stack.pop() == 8
 
 
 def test_shr_big(context):
-    SHR.execute(with_stack(context, [16, 5]))
+    SHR(with_stack(context, [16, 5]))
     assert context.stack.pop() == 0
 
 
 def test_shr_by_zero(context):
-    SHR.execute(with_stack(context, [16, 0]))
+    SHR(with_stack(context, [16, 0]))
     assert context.stack.pop() == 16
 
 
 def test_shr_non_power_of_two(context):
-    SHR.execute(with_stack(context, [15, 1]))
+    SHR(with_stack(context, [15, 1]))
     assert context.stack.pop() == 7
 
 
-def test_shl_non_power_of_two(context):
-    SHL.execute(with_stack(context, [15, 1]))
-    assert context.stack.pop() == 30
-
 def test_sar(context):
-    SAR.execute(with_stack(context,[0x80000000000000000000000000000000000000000000000000000000000000ff,2]))
+    SAR(with_stack(context,[0x80000000000000000000000000000000000000000000000000000000000000ff,2]))
     assert context.stack.pop() == 0xe00000000000000000000000000000000000000000000000000000000000003f
 
-    SAR.execute(with_stack(context,[0x70000000000000000000000000000000000000000000000000000000000000ff,2]))
+    SAR(with_stack(context,[0x70000000000000000000000000000000000000000000000000000000000000ff,2]))
     assert context.stack.pop() == 0x1c0000000000000000000000000000000000000000000000000000000000003f
 
 def test_byte(context):
-    BYTE.execute(with_stack(context, [0xABCDEF0908070605040302010000000000000000000000000000000000000000, 0]))
+    BYTE(with_stack(context, [0xABCDEF0908070605040302010000000000000000000000000000000000000000, 0]))
     assert context.stack.pop() == 0xAB
 
-    BYTE.execute(with_stack(context, [0xABCDEF0908070605040302010000000000000000000000000000000000000000, 1]))
+    BYTE(with_stack(context, [0xABCDEF0908070605040302010000000000000000000000000000000000000000, 1]))
     assert context.stack.pop() == 0xCD
 
-    BYTE.execute(with_stack(context, [0x00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff, 0]))
+    BYTE(with_stack(context, [0x00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff, 0]))
     assert context.stack.pop() == 0x00
 
-    BYTE.execute(with_stack(context, [0x00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff, 1]))
+    BYTE(with_stack(context, [0x00CDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff, 1]))
     assert context.stack.pop() == 0xCD
 
-    BYTE.execute(with_stack(context, [0x0000000000000000000000000000000000000000000000000000000000102030, 31]))
+    BYTE(with_stack(context, [0x0000000000000000000000000000000000000000000000000000000000102030, 31]))
     assert context.stack.pop() == 0x30
 
-    BYTE.execute(with_stack(context, [0x0000000000000000000000000000000000000000000000000000000000102030, 30]))
+    BYTE(with_stack(context, [0x0000000000000000000000000000000000000000000000000000000000102030, 30]))
     assert context.stack.pop() == 0x20
 
-    BYTE.execute(with_stack(context, [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 32]))
+    BYTE(with_stack(context, [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 32]))
     assert context.stack.pop() == 0x00
 
-    BYTE.execute(with_stack(context, [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 255]))
+    BYTE(with_stack(context, [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 255]))
     assert context.stack.pop() == 0x00

--- a/tests/test_calldata.py
+++ b/tests/test_calldata.py
@@ -18,28 +18,28 @@ def test_simple_calldataload(context):
     ctx = with_calldata(context, range(32))
     ctx.stack.push(0)
 
-    CALLDATALOAD.execute(ctx)
+    CALLDATALOAD(ctx)
     assert ctx.stack.pop() == 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 
 
 def test_empty_calldataload(context):
     context.stack.push(0)
-    CALLDATALOAD.execute(context)
+    CALLDATALOAD(context)
     assert context.stack.pop() == 0
 
 
 def test_calldataload_uint256_overflow(context):
     # 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff35
     context.stack.push(MAX_UINT256)
-    CALLDATALOAD.execute(context)
+    CALLDATALOAD(context)
     assert context.stack.pop() == 0
 
 def test_calldatasize_empty(context):
-    CALLDATASIZE.execute(context)
+    CALLDATASIZE(context)
     assert context.stack.pop() == 0
 
 def test_calldatasize_one(context):
-    CALLDATASIZE.execute(with_calldata(context, [0]))
+    CALLDATASIZE(with_calldata(context, [0]))
     assert context.stack.pop() == 1
 
 
@@ -48,14 +48,14 @@ def test_calldataload(context):
     ctx.stack.push(33)
     ctx.stack.push(0)
     ctx.stack.push(0)
-    CALLDATACOPY.execute(ctx)
+    CALLDATACOPY(ctx)
     # loading word from memory offset 0
     context.stack.push(0)
-    MLOAD.execute(context)
+    MLOAD(context)
     assert context.stack.pop() == int("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",16)
     # loading word from memory offset 0x20 (32)
     context.stack.push(32)
-    MLOAD.execute(context)
+    MLOAD(context)
     assert context.stack.pop() == int("0x1100000000000000000000000000000000000000000000000000000000000000",16)
 
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -11,67 +11,67 @@ def context() -> ExecutionContext:
     return ExecutionContext()
 
 def test_lt_equal(context):
-    LT.execute(with_stack(context, [1, 1]))
+    LT(with_stack(context, [1, 1]))
     assert context.stack.pop() == 0
 
 def test_lt_simple(context):
-    LT.execute(with_stack(context, [1, 0]))
+    LT(with_stack(context, [1, 0]))
     assert context.stack.pop() == 1
 
 def test_gt_equal(context):
-    GT.execute(with_stack(context, [1, 1]))
+    GT(with_stack(context, [1, 1]))
     assert context.stack.pop() == 0
 
 def test_gt_simple(context):
-    GT.execute(with_stack(context, [0, 1]))
+    GT(with_stack(context, [0, 1]))
     assert context.stack.pop() == 1
 
 def test_slt_equal(context):
-    SLT.execute(with_stack(context, [int_to_uint(-1), int_to_uint(-1)]))
+    SLT(with_stack(context, [int_to_uint(-1), int_to_uint(-1)]))
     assert context.stack.pop() == 0
 
 def test_slt_simple(context):
-    SLT.execute(with_stack(context, [10, int_to_uint(-1)]))
+    SLT(with_stack(context, [10, int_to_uint(-1)]))
     assert context.stack.pop() == 1
 
 def test_slt_extreme(context):
     # MAX_UINT256 is -1
-    SLT.execute(with_stack(context, [10, MAX_UINT256]))
+    SLT(with_stack(context, [10, MAX_UINT256]))
     assert context.stack.pop() == 1
 
 def test_sgt_equal(context):
-    SGT.execute(with_stack(context, [1, 1]))
+    SGT(with_stack(context, [1, 1]))
     assert context.stack.pop() == 0
 
 def test_sgt_simple(context):
-    SGT.execute(with_stack(context, [int_to_uint(-5), 10]))
+    SGT(with_stack(context, [int_to_uint(-5), 10]))
     assert context.stack.pop() == 1
 
 def test_sgt_extreme(context):
     # MAX_UINT256 is -1
-    SGT.execute(with_stack(context, [MAX_UINT256, 10]))
+    SGT(with_stack(context, [MAX_UINT256, 10]))
     assert context.stack.pop() == 1
 
 def test_eq_simple(context):
-    EQ.execute(with_stack(context, [1, 1]))
+    EQ(with_stack(context, [1, 1]))
     assert context.stack.pop() == 1
 
 def test_eq_big(context):
-    EQ.execute(with_stack(context, [MAX_UINT256, MAX_UINT256]))
+    EQ(with_stack(context, [MAX_UINT256, MAX_UINT256]))
     assert context.stack.pop() == 1
 
 def test_eq_zero(context):
-    EQ.execute(with_stack(context, [0, 0]))
+    EQ(with_stack(context, [0, 0]))
     assert context.stack.pop() == 1
 
 def test_eq_not_equal(context):
-    EQ.execute(with_stack(context, [1, 0]))
+    EQ(with_stack(context, [1, 0]))
     assert context.stack.pop() == 0
 
 def test_iszero_zero(context):
-    ISZERO.execute(with_stack(context, [1, 0]))
+    ISZERO(with_stack(context, [1, 0]))
     assert context.stack.pop() == 1
 
 def test_iszero_notzero(context):
-    ISZERO.execute(with_stack(context, [0, 1]))
+    ISZERO(with_stack(context, [0, 1]))
     assert context.stack.pop() == 0

--- a/tests/test_jumps.py
+++ b/tests/test_jumps.py
@@ -31,7 +31,7 @@ def test_jump_into_push_arg():
     """can only jump on instructions boundaries, so can't fool the EVM by packing a JUMPDEST in a PUSH argument"""
     # 605b600156
     code = assemble([
-        PUSH1, JUMPDEST.opcode,
+        PUSH1, 0x5B,
         PUSH1, 1,
         JUMP
     ])

--- a/tests/test_sha3.py
+++ b/tests/test_sha3.py
@@ -11,7 +11,7 @@ def context() -> ExecutionContext:
 
 
 def test_sha3_simple(context):
-    SHA3.execute(
+    SHA3(
         with_stack(
             with_memory(context, 0, [ord(x) for x in ["a", "b", "c"]]),
             [3, 0]
@@ -20,7 +20,7 @@ def test_sha3_simple(context):
     assert context.stack.pop() == 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
 
 def test_sha3_offset(context):
-    SHA3.execute(
+    SHA3(
         with_stack(
             with_memory(context, 0, [ord(x) for x in "foobarbaz"]),
             [3, 6]
@@ -29,5 +29,5 @@ def test_sha3_offset(context):
     assert context.stack.pop() == 0xf2d05ec5c5729fb559780c70a93ca7b4ee2ca37f64e62fa31046b324f60d9447
 
 def test_sha3_empty(context):
-    SHA3.execute(with_stack(context, [0, 0]))
+    SHA3(with_stack(context, [0, 0]))
     assert context.stack.pop() == 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -99,18 +99,18 @@ def test_peek_underflow(stack):
         stack.peek(1)
 
 def test_dup1(context):
-    DUP1.execute(with_stack(context, [1, 2, 3]))
+    DUP1(with_stack(context, [1, 2, 3]))
     assert context.stack.pop() == 3
     assert context.stack.pop() == 3
     assert context.stack.pop() == 2
 
 def test_dup2(context):
-    DUP2.execute(with_stack(context, [1, 2, 3]))
+    DUP2(with_stack(context, [1, 2, 3]))
     assert context.stack.pop() == 2
     assert context.stack.pop() == 3
     assert context.stack.pop() == 2
 
 def test_pop_instruction(context):
-    POP.execute(with_stack(context, [1, 2, 3]))
+    POP(with_stack(context, [1, 2, 3]))
     assert context.stack.pop() == 2
     assert context.stack.pop() == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -36,27 +36,27 @@ def test_invalid_value_too_big(context):
 
 def test_simple_sload_uninitialised(context):
     # reading uninitialised storage slot 0
-    SLOAD.execute(with_stack(context, (0,)))
+    SLOAD(with_stack(context, (0,)))
     assert context.stack.pop() == 0
 
 
 def test_simple_sload_preinitialized(context):
     context.storage.put(1, 42)
-    SLOAD.execute(with_stack(context, (1,)))
+    SLOAD(with_stack(context, (1,)))
     assert context.stack.pop() == 42
 
 
 def test_simple_sstore(context):
-    SSTORE.execute(with_stack(context, (1, 1,)))
+    SSTORE(with_stack(context, (1, 1,)))
     assert context.storage.get(0) == 0
     assert context.storage.get(1) == 1
 
 
 def test_overwrite_sstore(context):
     slot, init_value = 1, 1
-    SSTORE.execute(with_stack(context, (init_value, slot)))
+    SSTORE(with_stack(context, (init_value, slot)))
 
     overwrite_value = 42
-    SSTORE.execute(with_stack(context, (overwrite_value, slot,)))
+    SSTORE(with_stack(context, (overwrite_value, slot,)))
     assert context.storage.get(slot) == overwrite_value
 


### PR DESCRIPTION
- define an InstructionRegistry that lets us look up instructions by opcode, name and execution function
- introduce the `@insn` function decorator: we directly decorate a function name, annotate it with its opcode, derive its name from the function name, and add it to the registry

This makes it a lot easier to work with named functions (as opposed to lambdas, they can get awkward because everything has to fit in a single expression)