### PR TITLE
Add PUSH0 opcode

### DIFF
--- a/src/smol_evm/opcodes.py
+++ b/src/smol_evm/opcodes.py
@@ -528,6 +528,11 @@ if os.getenv("DEBUG"):
     print(REGISTRY.by_code)
 
 
+@insn(0x5F)
+def PUSH0(ctx: ExecutionContext) -> None:
+    ctx.stack.push(0)
+
+
 def PUSH(value: int) -> Instruction:
     """
     Returns the PUSH instruction for the given value, using the smallest possible PUSH instruction

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,6 +1,6 @@
 from smol_evm.constants import MAX_UINT256
 from smol_evm.context import ExecutionContext
-from smol_evm.opcodes import DUP1, DUP2, POP
+from smol_evm.opcodes import DUP1, DUP2, POP, PUSH0
 from smol_evm.stack import Stack, StackOverflow, StackUnderflow, InvalidStackItem
 
 from shared import with_stack
@@ -98,6 +98,10 @@ def test_peek_underflow(stack):
     with pytest.raises(StackUnderflow):
         stack.peek(1)
 
+def test_push0(context):
+    PUSH0(context)
+    assert context.stack.pop() == 0
+    
 def test_dup1(context):
     DUP1(with_stack(context, [1, 2, 3]))
     assert context.stack.pop() == 3


### PR DESCRIPTION
The PUSH0 opcode will be used by default in the latest version of huff. This commit adds the PUSH0 opcode.